### PR TITLE
Change formatter to string encode int64

### DIFF
--- a/bravado_core/formatter.py
+++ b/bravado_core/formatter.py
@@ -143,7 +143,7 @@ DEFAULT_FORMATS = {
         description='Converts [wire]integer:int32 <=> python int'),
     'int64': SwaggerFormat(
         format='int64',
-        to_wire=lambda i: i if isinstance(i, long) else long(i),
+        to_wire=lambda i: i if isinstance(i, str) else str(i),
         to_python=lambda i: i if isinstance(i, long) else long(i),
         validate=NO_OP,  # jsonschema validates integer
         description='Converts [wire]integer:int64 <=> python long'),


### PR DESCRIPTION
int64 can go beyond the size supported by JavaScript. For this reason the swagger created by go-gen-grpc casts int64 to string type. To support this feature we override the long cast.